### PR TITLE
Range log

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,16 +4,15 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-17" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,29 +54,30 @@ android {
 
 dependencies {
 
-    implementation("androidx.core:core-ktx:1.9.0")
-    implementation("androidx.activity:activity-compose:1.7.0")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0")
-    implementation("androidx.activity:activity-compose:1.8.2")
-    implementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.1")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.1")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.1")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:2.8.1")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation(platform("androidx.compose:compose-bom:2024.05.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material3:material3-android:1.2.1")
 //    implementation("androidx.navigation:navigation-runtime-ktx:2.7.7")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.05.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 
     // navagation
-    implementation ("androidx.navigation:navigation-compose:2.5.3")
+    implementation ("androidx.navigation:navigation-compose:2.7.7")
 
     // material
     implementation ("androidx.compose.material:material-icons-core")
@@ -84,7 +85,7 @@ dependencies {
     implementation ("androidx.compose.material:material-icons-extended")
 
     // LiveData
-    implementation ("androidx.lifecycle:lifecycle-livedata-ktx:2.7.0")
+    implementation ("androidx.lifecycle:lifecycle-livedata-ktx:2.8.1")
 //    // ViewModel
 //    implementation ("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
 //    implementation ("androidx.lifecycle:lifecycle-viewmodel-runtime-ktx:2.5.1")

--- a/app/src/main/java/com/example/composegolfbuddy/ClubsApplication.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/ClubsApplication.kt
@@ -1,8 +1,8 @@
 package com.example.composegolfbuddy
 
 import android.app.Application
-import com.multiplatform.clubdistances.data.ClubRoomDatabase
-import com.multiplatform.clubdistances.homeScreen.repositories.ClubsRepositoryImpl
+import com.example.composegolfbuddy.data.ClubRoomDatabase
+import com.example.composegolfbuddy.repositories.ClubsRepositoryImpl
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob

--- a/app/src/main/java/com/example/composegolfbuddy/MainActivity.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/MainActivity.kt
@@ -14,7 +14,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.composegolfbuddy.screens.GbViewModel
 import com.example.composegolfbuddy.screens.GolfBuddyScreen
-import com.example.composegolfbuddy.ui.theme.ComposeGolfBuddyTheme
+import com.example.composegolfbuddy.designsystem.ui.theme.ComposeGolfBuddyTheme
+import com.example.composegolfbuddy.screens.rangelogs.RangeLogsViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -22,6 +23,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val viewModel by viewModels<GbViewModel>()
+        val rangeLogsViewModel by viewModels<RangeLogsViewModel>()
 
         setContent {
             ComposeGolfBuddyTheme {
@@ -30,7 +32,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    GolfBuddyScreen(viewModel)
+                    GolfBuddyScreen(viewModel, rangeLogsViewModel)
                 }
             }
         }

--- a/app/src/main/java/com/example/composegolfbuddy/data/ClubRoomDatabase.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/data/ClubRoomDatabase.kt
@@ -1,27 +1,34 @@
-package com.multiplatform.clubdistances.data
+package com.example.composegolfbuddy.data
 
 import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.multiplatform.clubdistances.data.dao.ClubDao
+import com.example.composegolfbuddy.data.dao.ClubDao
+import com.example.composegolfbuddy.data.dao.RangeLogsDao
+import com.example.composegolfbuddy.model.RangeLog
 import com.multiplatform.clubdistances.homeScreen.model.Club
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 // Annotates class to be a Room Database with a table (entity) of the Club class
-@Database(entities = arrayOf(Club::class), version = 1, exportSchema = false)
+@Database(
+    entities = arrayOf(
+        Club::class,
+        RangeLog::class
+    ), version = 1, exportSchema = false)
 abstract class ClubRoomDatabase : RoomDatabase() {
 
     abstract fun getClubDao(): ClubDao
+    abstract fun getRangeLogsDao(): RangeLogsDao
 
     private class ClubDatabaseCallback(
         private val scope: CoroutineScope
     ) : RoomDatabase.Callback() {
         override fun onCreate(db: SupportSQLiteDatabase) {
             super.onCreate(db)
-            INSTANCE?.let {database ->
+            INSTANCE?.let { database ->
                 scope.launch {
                     populateDatabase(database.getClubDao())
                 }

--- a/app/src/main/java/com/example/composegolfbuddy/data/dao/ClubDao.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/data/dao/ClubDao.kt
@@ -1,6 +1,9 @@
-package com.multiplatform.clubdistances.data.dao
+package com.example.composegolfbuddy.data.dao
 
-import androidx.room.*
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
 import com.multiplatform.clubdistances.homeScreen.model.Club
 import kotlinx.coroutines.flow.Flow
 

--- a/app/src/main/java/com/example/composegolfbuddy/data/dao/RangeLogsDao.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/data/dao/RangeLogsDao.kt
@@ -15,4 +15,7 @@ interface RangeLogsDao {
     @Insert
     suspend fun insert(rangeLog: RangeLog)
 
+    @Query("DELETE FROM range_log Where id = :id")
+    suspend fun deleteById(id: String)
+
 }

--- a/app/src/main/java/com/example/composegolfbuddy/data/dao/RangeLogsDao.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/data/dao/RangeLogsDao.kt
@@ -1,0 +1,18 @@
+package com.example.composegolfbuddy.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.example.composegolfbuddy.model.RangeLog
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface RangeLogsDao {
+
+    @Query("SELECT * FROM range_log")
+    fun getAll(): Flow<List<RangeLog>>
+
+    @Insert
+    suspend fun insert(rangeLog: RangeLog)
+
+}

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/ActionButton.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/ActionButton.kt
@@ -1,0 +1,37 @@
+package com.example.composegolfbuddy.designsystem.compents
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ActionButton(doAction: () -> Unit, icon: ImageVector, textValue: String) {
+    ElevatedButton(
+        onClick = { doAction() }, // Wrap the function call in a lambda
+        colors = ButtonDefaults.elevatedButtonColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+        )
+    ) {
+        Text(
+            text = textValue,
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Icon(
+            icon,
+            "description",
+            modifier = Modifier
+                .padding(4.dp)
+                .size(26.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/BoldTextTitleWithContent.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/BoldTextTitleWithContent.kt
@@ -1,0 +1,30 @@
+package com.example.composegolfbuddy.designsystem.compents
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun BoldTextTitleWithContent(
+    titleTextValue: String,
+    contentTextValue: String,
+    size:Int) {
+    Row {
+        Text(
+            text = titleTextValue,
+            style = TextStyle(
+                fontSize = size.sp,
+                fontWeight = FontWeight.Bold
+            )
+        )
+        Text(
+            text = contentTextValue,
+            style = TextStyle(
+                fontSize = size.sp,
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/ElevatedCreateButton.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/ElevatedCreateButton.kt
@@ -1,0 +1,26 @@
+package com.example.composegolfbuddy.designsystem.compents
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Create
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ElevatedCreateButton() {
+    ElevatedButton(onClick = { /*TODO*/ }) {
+        Icon(
+            Icons.Filled.Create,
+            "description",
+            modifier = Modifier
+                .padding(4.dp)
+                .size(32.dp)
+        )
+        Text(text = "Create")
+    }
+}

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/MyDatePicker.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/MyDatePicker.kt
@@ -1,0 +1,115 @@
+package com.example.composegolfbuddy.designsystem.compents
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Button
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SelectableDates
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import java.text.SimpleDateFormat
+import java.util.Date
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MyDatePickerDialog(
+//    modifier: Modifier = Modifier,
+    onDateSelected: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val datePickerState = rememberDatePickerState(selectableDates = object : SelectableDates {
+        override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+            return utcTimeMillis <= System.currentTimeMillis()
+        }
+    })
+
+    val selectedDate = datePickerState.selectedDateMillis?.let {
+        convertMillisToDate(it)
+    } ?: ""
+
+    DatePickerDialog(
+        onDismissRequest = { onDismiss() },
+        confirmButton = {
+            Button(onClick = {
+                onDateSelected(selectedDate)
+                onDismiss()
+            }
+
+            ) {
+                Text(text = "OK")
+            }
+        },
+        dismissButton = {
+            Button(onClick = {
+                onDismiss()
+            }) {
+                Text(text = "Cancel")
+            }
+        }
+    ) {
+        DatePicker(
+            state = datePickerState
+        )
+    }
+}
+
+@Composable
+fun MyDatePickerDialog(
+    modifier: Modifier = Modifier,
+    updateDate: (String) -> Unit,
+) {
+    var date by remember {
+        mutableStateOf("")
+    }
+
+    var showDatePicker by remember {
+        mutableStateOf(false)
+    }
+
+    Box(contentAlignment = Alignment.Center) {
+
+        OutlinedTextField(
+            modifier = modifier,
+            value = date,
+            onValueChange = {},
+            label = {
+                Text(
+                    text = "Select Date",
+                    modifier = Modifier.clickable(enabled = true,
+                        onClickLabel = "Select Date",
+                        onClick = {
+                            showDatePicker = true
+                        }
+                    )
+                )
+            },
+            readOnly = true,
+        )
+
+    }
+
+    if (showDatePicker) {
+        MyDatePickerDialog(
+            onDateSelected = {
+                date = it
+                updateDate(it)
+             },
+            onDismiss = { showDatePicker = false }
+        )
+    }
+}
+
+private fun convertMillisToDate(millis: Long): String {
+    val formatter = SimpleDateFormat("dd/MM/yyyy")
+    return formatter.format(Date(millis))
+}

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/MyDatePicker.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/MyDatePicker.kt
@@ -23,7 +23,6 @@ import java.util.Date
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MyDatePickerDialog(
-//    modifier: Modifier = Modifier,
     onDateSelected: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -66,11 +65,10 @@ fun MyDatePickerDialog(
 @Composable
 fun MyDatePickerDialog(
     modifier: Modifier = Modifier,
-    updateDate: (String) -> Unit,
+    initialDate: String,
+    updateDate: (String) -> Unit
+
 ) {
-    var date by remember {
-        mutableStateOf("")
-    }
 
     var showDatePicker by remember {
         mutableStateOf(false)
@@ -80,7 +78,7 @@ fun MyDatePickerDialog(
 
         OutlinedTextField(
             modifier = modifier,
-            value = date,
+            value = initialDate,
             onValueChange = {},
             label = {
                 Text(
@@ -95,13 +93,11 @@ fun MyDatePickerDialog(
             },
             readOnly = true,
         )
-
     }
 
     if (showDatePicker) {
         MyDatePickerDialog(
             onDateSelected = {
-                date = it
                 updateDate(it)
              },
             onDismiss = { showDatePicker = false }

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/OutlinedLargeTextField.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/OutlinedLargeTextField.kt
@@ -1,0 +1,31 @@
+package com.example.composegolfbuddy.designsystem.compents
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+
+@Composable
+fun OutlinedLargeTextField(
+    initialValue: String = "",
+    valueChanged: (String) -> Unit,
+    title: String = "",
+    maxLength: Int,
+) {
+        OutlinedTextField(
+//            modifier = Modifier.height(500.dp),
+            shape = MaterialTheme.shapes.large,
+            value = initialValue,
+            onValueChange = { newValue ->
+                if (!newValue.endsWith(' ')) {
+                    if (newValue.length <= maxLength) {
+                        valueChanged(newValue)
+                    }
+                }
+            },
+            label = { Text(title) },
+            singleLine = false,
+            minLines = 5
+        )
+}

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/OutlinedLargeTextField.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/OutlinedLargeTextField.kt
@@ -4,6 +4,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 
 
 @Composable
@@ -13,19 +17,22 @@ fun OutlinedLargeTextField(
     title: String = "",
     maxLength: Int,
 ) {
+    var length by rememberSaveable { mutableStateOf(0) }
         OutlinedTextField(
-//            modifier = Modifier.height(500.dp),
             shape = MaterialTheme.shapes.large,
             value = initialValue,
             onValueChange = { newValue ->
-                if (!newValue.endsWith(' ')) {
-                    if (newValue.length <= maxLength) {
-                        valueChanged(newValue)
-                    }
+                if(newValue.length <= maxLength) {
+                    valueChanged(newValue)
+                    length = newValue.length
+                } else {
+                    valueChanged(newValue.substring(0, maxLength))
+                    length = maxLength
                 }
             },
             label = { Text(title) },
             singleLine = false,
-            minLines = 5
+            minLines = 5,
+            supportingText = { Text("$length/$maxLength")}
         )
 }

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/OutlinedTextFieldForInputs.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/OutlinedTextFieldForInputs.kt
@@ -1,0 +1,69 @@
+package com.example.composegolfbuddy.designsystem.compents
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OutlinedTextFieldForInputs(
+    initialValue: String = "",
+    valueChanged: (String) -> Unit,
+    isErrorState: Boolean = false,
+    errorMessage: String,
+    title: String = "",
+    maxLength: Int
+) {
+    Column(horizontalAlignment = Alignment.Start) {
+        OutlinedTextField(
+            value = initialValue,
+            onValueChange = { newValue ->
+                if (!newValue.endsWith(' ')) {
+                    if (newValue.length <= maxLength) {
+                        valueChanged(newValue)
+                    }
+                }
+            },
+            label = { Text(title) },
+            isError = isErrorState,
+            supportingText = {
+                if (isErrorState) {
+                    Text(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = errorMessage,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            },
+            singleLine = true
+        )
+    }
+}
+
+//@Preview
+//@Composable
+//fun PreviewOutlinedTextFieldForInputs() {
+//    OutlinedTextFieldForInputs(
+//        initialValue = "",
+//        valueChanged = viewModel.,
+//        isErrorState = false,
+//        errorMessage =,"errorMessage",
+//        title = "Distance",
+//        maxLength = 3
+//    )
+//}

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/OutlinedTextFieldForInputs.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/OutlinedTextFieldForInputs.kt
@@ -1,25 +1,13 @@
 package com.example.composegolfbuddy.designsystem.compents
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OutlinedTextFieldForInputs(
     initialValue: String = "",
@@ -27,43 +15,30 @@ fun OutlinedTextFieldForInputs(
     isErrorState: Boolean = false,
     errorMessage: String,
     title: String = "",
-    maxLength: Int
+    maxLength: Int,
+    modifier: Modifier = Modifier
 ) {
-    Column(horizontalAlignment = Alignment.Start) {
-        OutlinedTextField(
-            value = initialValue,
-            onValueChange = { newValue ->
-                if (!newValue.endsWith(' ')) {
-                    if (newValue.length <= maxLength) {
-                        valueChanged(newValue)
-                    }
+    OutlinedTextField(
+        value = initialValue,
+        onValueChange = { newValue ->
+            if (!newValue.endsWith(' ')) {
+                if (newValue.length <= maxLength) {
+                    valueChanged(newValue)
                 }
-            },
-            label = { Text(title) },
-            isError = isErrorState,
-            supportingText = {
-                if (isErrorState) {
-                    Text(
-                        modifier = Modifier.fillMaxWidth(),
-                        text = errorMessage,
-                        color = MaterialTheme.colorScheme.error
-                    )
-                }
-            },
-            singleLine = true
-        )
-    }
+            }
+        },
+        label = { Text(title) },
+        isError = isErrorState,
+        supportingText = {
+            if (isErrorState) {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = errorMessage,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        },
+        singleLine = true
+    )
 }
 
-//@Preview
-//@Composable
-//fun PreviewOutlinedTextFieldForInputs() {
-//    OutlinedTextFieldForInputs(
-//        initialValue = "",
-//        valueChanged = viewModel.,
-//        isErrorState = false,
-//        errorMessage =,"errorMessage",
-//        title = "Distance",
-//        maxLength = 3
-//    )
-//}

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/OutlinedTextFieldWithDropdown.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/OutlinedTextFieldWithDropdown.kt
@@ -1,0 +1,91 @@
+package com.example.composegolfbuddy.designsystem.compents
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OutlinedTextFieldWithDropdown(
+    initialValue: String = "",
+    valueChanged: (String) -> Unit,
+    retrieveClub: () -> Unit,
+    indexChanged: (Int) -> Unit,
+    selectedIndex: Int,
+    isErrorState: Boolean = false,
+    errorMessage: String,
+    title: String = "",
+    options: List<String>
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(horizontalAlignment = Alignment.Start) {
+        Box(modifier = Modifier.clickable { expanded = true }) {
+            OutlinedTextField(
+                value = if (selectedIndex != -1) options[selectedIndex] else initialValue,
+                onValueChange = {
+                    valueChanged(it)
+                },
+                label = { Text(title) },
+                isError = isErrorState,
+                readOnly = true,
+                singleLine = true,
+                trailingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.ArrowDropDown,
+                        contentDescription = "Dropdown",
+                        modifier = Modifier.clickable { expanded = true }
+                    )
+                }
+            )
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(400.dp)
+        ) {
+            options.forEachIndexed { index, option ->
+                DropdownMenuItem(
+                    text = { Text(text = option) },
+                    onClick = {
+                        valueChanged(option)
+                        retrieveClub()
+                        indexChanged(index)
+                        expanded = false
+                    }
+                )
+            }
+        }
+
+        if (isErrorState) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = errorMessage,
+                color = MaterialTheme.colorScheme.error
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/RangeLogCard.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/RangeLogCard.kt
@@ -33,7 +33,10 @@ import androidx.compose.ui.unit.sp
 import com.example.composegolfbuddy.model.RangeLog
 
 @Composable
-fun RangeLogCard(rangeLog: RangeLog) {
+fun RangeLogCard(
+    rangeLog: RangeLog,
+    deleteRangeLogById: (String) -> Unit
+) {
     ElevatedCard(modifier = Modifier
         .fillMaxWidth()
         .padding(8.dp)
@@ -89,7 +92,7 @@ fun RangeLogCard(rangeLog: RangeLog) {
                         DropdownMenuItem(
                             text = { Text(text = "Delete") },
                             onClick = {
-                                // Delete Post
+                                deleteRangeLogById(rangeLog.id)
                                 expanded = false
                             }
                         )

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/RangeLogCard.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/RangeLogCard.kt
@@ -1,0 +1,119 @@
+package com.example.composegolfbuddy.designsystem.compents
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material.icons.filled.GolfCourse
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.composegolfbuddy.model.RangeLog
+
+@Composable
+fun RangeLogCard(rangeLog: RangeLog) {
+    ElevatedCard(modifier = Modifier
+        .fillMaxWidth()
+        .padding(8.dp)
+        .wrapContentHeight(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+        )
+
+    ){
+        var expanded by rememberSaveable { mutableStateOf(false) }
+
+        Column(){
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            )
+            {
+                Row(horizontalArrangement = Arrangement.Start)
+                {
+                    Icon(
+                        Icons.Filled.GolfCourse,
+                        "description",
+                        modifier = Modifier
+                            .padding(4.dp)
+                            .size(32.dp)
+                    )
+                    Column() {
+                        Text(
+                            text = rangeLog.location,
+                            style = TextStyle(
+                                fontSize = 16.sp
+                            )
+                        )
+                        Text(
+                            text = rangeLog.date,
+                            style = TextStyle(
+                                fontSize = 16.sp
+                            )
+                        )
+                    }
+                }
+                Row (modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End)
+                {
+                    IconButton(onClick = { expanded = true }) {
+                        Icon(Icons.Filled.DeleteOutline, "Floating action button.")
+                    }
+                    DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false },
+                        modifier = Modifier
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text(text = "Delete") },
+                            onClick = {
+                                // Delete Post
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+
+            Column(modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+            ){
+                BoldTextTitleWithContent(
+                    "Goal: ",
+                    rangeLog.goal,
+                    16
+                )
+                BoldTextTitleWithContent(
+                    "Balls hit: ",
+                    rangeLog.ballsHit,
+                    16
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                RangeLogNoteWithScroll(rangeLog.summary, size = 16)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/RangeLogNoteWithScroll.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/RangeLogNoteWithScroll.kt
@@ -1,38 +1,38 @@
 package com.example.composegolfbuddy.designsystem.compents
 
-import android.graphics.drawable.shapes.Shape
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults.shape
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 @Composable
 fun RangeLogNoteWithScroll(value: String, size: Int) {
-    Card(modifier = Modifier,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.inverseSurface)
-//        shape =
+    Card(modifier = Modifier.heightIn(max = 150.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow // Set your desired background color here
+        )
     ) {
-
         Text(
             text = value,
             style = TextStyle(
                 fontSize = size.sp
             ),
             modifier = Modifier
-                .padding(4.dp)
+                .padding(top = 8.dp, bottom = 8.dp, start = 4.dp, end = 4.dp)
                 .verticalScroll(rememberScrollState())
+                .fillMaxWidth()
         )
     }
 }

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/RangeLogNoteWithScroll.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/RangeLogNoteWithScroll.kt
@@ -1,0 +1,38 @@
+package com.example.composegolfbuddy.designsystem.compents
+
+import android.graphics.drawable.shapes.Shape
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults.shape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun RangeLogNoteWithScroll(value: String, size: Int) {
+    Card(modifier = Modifier,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.inverseSurface)
+//        shape =
+    ) {
+
+        Text(
+            text = value,
+            style = TextStyle(
+                fontSize = size.sp
+            ),
+            modifier = Modifier
+                .padding(4.dp)
+                .verticalScroll(rememberScrollState())
+        )
+    }
+}

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/SubmitButton.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/SubmitButton.kt
@@ -1,0 +1,18 @@
+package com.example.composegolfbuddy.designsystem.compents
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SubmitButton(modifier: Modifier = Modifier, processClubInputs: () -> Unit) {
+    Button(onClick = {
+        processClubInputs()
+    }) {
+        modifier.padding(8.dp)
+        Text(text = "Add Club")
+    }
+}

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/TextFields.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/compents/TextFields.kt
@@ -1,5 +1,0 @@
-package com.example.composegolfbuddy.designsystem.compents
-
-class TextFields() {
-    // migrate components
-}

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.example.composegolfbuddy.ui.theme
+package com.example.composegolfbuddy.designsystem.ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/ui/theme/Theme.kt
@@ -1,4 +1,4 @@
-package com.example.composegolfbuddy.ui.theme
+package com.example.composegolfbuddy.designsystem.ui.theme
 
 import android.app.Activity
 import android.os.Build

--- a/app/src/main/java/com/example/composegolfbuddy/designsystem/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/designsystem/ui/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.example.composegolfbuddy.ui.theme
+package com.example.composegolfbuddy.designsystem.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle

--- a/app/src/main/java/com/example/composegolfbuddy/di/DaoModule.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/di/DaoModule.kt
@@ -2,7 +2,7 @@ package com.example.composegolfbuddy.di
 
 import android.content.Context
 import androidx.room.Room
-import com.multiplatform.clubdistances.data.ClubRoomDatabase
+import com.example.composegolfbuddy.data.ClubRoomDatabase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -15,6 +15,9 @@ import javax.inject.Singleton
 object DaoModule {
     @Provides
     fun provideClubDao(clubRooDatabase: ClubRoomDatabase) = clubRooDatabase.getClubDao()
+
+    @Provides
+    fun provideRangeLogsDao(clubRooDatabase: ClubRoomDatabase) = clubRooDatabase.getRangeLogsDao()
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/example/composegolfbuddy/di/RepositoriesModule.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/di/RepositoriesModule.kt
@@ -1,10 +1,13 @@
 package com.example.composegolfbuddy.di
 
+import com.example.composegolfbuddy.data.dao.ClubDao
+import com.example.composegolfbuddy.data.dao.RangeLogsDao
 import com.example.composegolfbuddy.repositories.ClubTypesRepository
 import com.example.composegolfbuddy.repositories.ClubsRepository
-import com.multiplatform.clubdistances.data.dao.ClubDao
+import com.example.composegolfbuddy.repositories.ClubsRepositoryImpl
+import com.example.composegolfbuddy.repositories.RangeLogsRepository
+import com.example.composegolfbuddy.repositories.RangeLogsRepositoryImpl
 import com.multiplatform.clubdistances.homeScreen.model.ClubTypes
-import com.multiplatform.clubdistances.homeScreen.repositories.ClubsRepositoryImpl
 import com.multiplatform.clubdistances.updateClubs.repositories.ClubTypesRepositoryImpl
 import dagger.Module
 import dagger.Provides
@@ -23,5 +26,10 @@ object RepositoriesModule {
     @Provides
     fun provideClubTypesRepository(): ClubTypesRepository {
         return ClubTypesRepositoryImpl(ClubTypes())
+    }
+
+    @Provides
+    fun provideRangeLogsRepository(rangeLogsDao: RangeLogsDao): RangeLogsRepository {
+        return RangeLogsRepositoryImpl(rangeLogsDao)
     }
 }

--- a/app/src/main/java/com/example/composegolfbuddy/model/RangeLog.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/model/RangeLog.kt
@@ -1,10 +1,15 @@
 package com.example.composegolfbuddy.model
 
-data class RangeLog(
-    val location: String = "",
-    val date: String = "",
-    val goal: String = "",
-    val ballShit: String = "",
-    val note: String = ""
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 
+@Entity(tableName = "range_log")
+data class RangeLog(
+    @PrimaryKey @ColumnInfo("id") val id: String,
+    @ColumnInfo("location") val location: String = "",
+    @ColumnInfo("date")val date: String = "",
+    @ColumnInfo("goal") val goal: String = "",
+    @ColumnInfo("balls_hit") val ballsHit: String = "",
+    @ColumnInfo("summary") val summary: String = ""
 )

--- a/app/src/main/java/com/example/composegolfbuddy/model/RangeLog.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/model/RangeLog.kt
@@ -1,0 +1,10 @@
+package com.example.composegolfbuddy.model
+
+data class RangeLog(
+    val location: String = "",
+    val date: String = "",
+    val goal: String = "",
+    val ballShit: String = "",
+    val note: String = ""
+
+)

--- a/app/src/main/java/com/example/composegolfbuddy/repositories/ClubsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/repositories/ClubsRepositoryImpl.kt
@@ -1,8 +1,7 @@
-package com.multiplatform.clubdistances.homeScreen.repositories
+package com.example.composegolfbuddy.repositories
 
 import androidx.annotation.WorkerThread
-import com.example.composegolfbuddy.repositories.ClubsRepository
-import com.multiplatform.clubdistances.data.dao.ClubDao
+import com.example.composegolfbuddy.data.dao.ClubDao
 import com.multiplatform.clubdistances.homeScreen.model.Club
 import kotlinx.coroutines.flow.Flow
 
@@ -17,7 +16,6 @@ class ClubsRepositoryImpl(private val clubDao: ClubDao) : ClubsRepository {
     // By default Room runs suspend queries off the main thread, therefore, we don't need to
     // implement anything else to ensure we're not doing long running database work
     // off the main thread.
-    @Suppress("RedundantSuspendModifier")
     @WorkerThread
     override suspend fun insert(club: Club) {
         clubDao.insert(club)

--- a/app/src/main/java/com/example/composegolfbuddy/repositories/RangeLogsRepository.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/repositories/RangeLogsRepository.kt
@@ -1,0 +1,11 @@
+package com.example.composegolfbuddy.repositories
+
+import com.example.composegolfbuddy.model.RangeLog
+import kotlinx.coroutines.flow.Flow
+
+interface RangeLogsRepository {
+
+    suspend fun insertRangeLog(rangeLog: RangeLog)
+
+    fun getAllRangeLogs(): Flow<List<RangeLog>>
+}

--- a/app/src/main/java/com/example/composegolfbuddy/repositories/RangeLogsRepository.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/repositories/RangeLogsRepository.kt
@@ -8,4 +8,6 @@ interface RangeLogsRepository {
     suspend fun insertRangeLog(rangeLog: RangeLog)
 
     fun getAllRangeLogs(): Flow<List<RangeLog>>
+
+    suspend fun deleteById(id: String)
 }

--- a/app/src/main/java/com/example/composegolfbuddy/repositories/RangeLogsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/repositories/RangeLogsRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.example.composegolfbuddy.repositories
+
+import com.example.composegolfbuddy.data.dao.RangeLogsDao
+import com.example.composegolfbuddy.model.RangeLog
+import kotlinx.coroutines.flow.Flow
+
+class RangeLogsRepositoryImpl(private val rangeLogsDao: RangeLogsDao): RangeLogsRepository {
+    override suspend fun insertRangeLog(rangeLog: RangeLog) {
+        rangeLogsDao.insert(rangeLog)
+    }
+
+    override fun getAllRangeLogs(): Flow<List<RangeLog>> {
+        return rangeLogsDao.getAll()
+    }
+}

--- a/app/src/main/java/com/example/composegolfbuddy/repositories/RangeLogsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/repositories/RangeLogsRepositoryImpl.kt
@@ -12,4 +12,8 @@ class RangeLogsRepositoryImpl(private val rangeLogsDao: RangeLogsDao): RangeLogs
     override fun getAllRangeLogs(): Flow<List<RangeLog>> {
         return rangeLogsDao.getAll()
     }
+
+    override suspend fun deleteById(id: String) {
+        rangeLogsDao.deleteById(id)    }
+
 }

--- a/app/src/main/java/com/example/composegolfbuddy/screens/GbViewModel.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/GbViewModel.kt
@@ -195,11 +195,11 @@ class GbViewModel @Inject constructor(
     }
 
     private fun resetFields(resetIndex: Boolean = true) {
-        updateClubTypeValue("")
         updateClubBrandValue("")
         updateClubLoftValue("")
         updateClubDistanceValue("")
         if (resetIndex) {
+            updateClubTypeValue("")
             updateClubTypeIndex(-1)
         }
     }

--- a/app/src/main/java/com/example/composegolfbuddy/screens/GbViewModel.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/GbViewModel.kt
@@ -7,11 +7,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.composegolfbuddy.screens.homeScreen.HomeScreenUiState
 import com.example.composegolfbuddy.screens.modifyclubsscreen.ModifyClubsStateUI
+import com.example.composegolfbuddy.usecases.AddClubUseCase
 import com.example.composegolfbuddy.usecases.GetClubTypesUseCase
 import com.example.composegolfbuddy.usecases.GetClubsStaticUseCase
 import com.example.composegolfbuddy.usecases.RetrieveClubByNameUseCase
 import com.multiplatform.clubdistances.homeScreen.model.Club
-import com.multiplatform.clubdistances.homeScreen.useCases.AddClubUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -93,7 +93,6 @@ class GbViewModel @Inject constructor(
             clearErrorStates()
             insertClub()
             resetFields()
-            populateClubsData()
         }
     }
 
@@ -213,6 +212,7 @@ class GbViewModel @Inject constructor(
                 distanceInput.toInt()
             )
         )
+        populateClubsData()
     }
 
 }

--- a/app/src/main/java/com/example/composegolfbuddy/screens/GolfBuddyScreen.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/GolfBuddyScreen.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.NoteAdd
 import androidx.compose.material.icons.filled.NoteAlt
 import androidx.compose.material.icons.filled.SportsGolf
 import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.NoteAdd
 import androidx.compose.material.icons.outlined.NoteAlt
 import androidx.compose.material.icons.outlined.SportsGolf
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -43,9 +45,9 @@ data class BottomNavigationItem(
 )
 
 enum class GolfBuddyScreenNames() {
-    Logs,
     Home,
     Clubs,
+    Logs,
     CreateLogs
 }
 
@@ -60,11 +62,6 @@ fun GolfBuddyScreen(
 
     val items = listOf(
         BottomNavigationItem(
-            title = "Range Logs",
-            selectedIcon = Icons.Filled.NoteAlt,
-            unSelectedIcon = Icons.Outlined.NoteAlt
-        ),
-        BottomNavigationItem(
             title = "Home",
             selectedIcon = Icons.Filled.Home,
             unSelectedIcon = Icons.Outlined.Home
@@ -73,11 +70,21 @@ fun GolfBuddyScreen(
             title = "clubs",
             selectedIcon = Icons.Filled.SportsGolf,
             unSelectedIcon = Icons.Outlined.SportsGolf
+        ),
+        BottomNavigationItem(
+            title = "Range Logs",
+            selectedIcon = Icons.Filled.NoteAlt,
+            unSelectedIcon = Icons.Outlined.NoteAlt
+        ),
+        BottomNavigationItem(
+            title = "Create Logs",
+            selectedIcon = Icons.Filled.NoteAdd,
+            unSelectedIcon = Icons.Outlined.NoteAdd
         )
     )
 
     var selectedIndex by rememberSaveable {
-        mutableStateOf(1)
+        mutableStateOf(0)
     }
     Scaffold(
         bottomBar = {
@@ -134,7 +141,10 @@ fun GolfBuddyScreen(
                     )
                 }
                 composable(route =GolfBuddyScreenNames.CreateLogs.name) {
-                    CreateRangeLogScreen(modifier = Modifier.fillMaxHeight())
+                    CreateRangeLogScreen(
+                        rangeLogsViewModel,
+                        modifier = Modifier.fillMaxHeight()
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/example/composegolfbuddy/screens/GolfBuddyScreen.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/GolfBuddyScreen.kt
@@ -1,6 +1,7 @@
 package com.example.composegolfbuddy.screens
 
 import android.annotation.SuppressLint
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -28,9 +29,11 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.example.composegolfbuddy.screens.createrangelog.CreateRangeLogScreen
 import com.example.composegolfbuddy.screens.homeScreen.HomeScreen
 import com.example.composegolfbuddy.screens.modifyclubsscreen.ModifyClubsScreen
 import com.example.composegolfbuddy.screens.rangelogs.RangeLogsScreen
+import com.example.composegolfbuddy.screens.rangelogs.RangeLogsViewModel
 
 
 data class BottomNavigationItem(
@@ -42,14 +45,16 @@ data class BottomNavigationItem(
 enum class GolfBuddyScreenNames() {
     Logs,
     Home,
-    Clubs
+    Clubs,
+    CreateLogs
 }
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GolfBuddyScreen(
-    viewModel: GbViewModel,
+    gbViewModel: GbViewModel,
+    rangeLogsViewModel: RangeLogsViewModel,
     navController: NavHostController = rememberNavController()
 ) {
 
@@ -74,40 +79,35 @@ fun GolfBuddyScreen(
     var selectedIndex by rememberSaveable {
         mutableStateOf(1)
     }
-
-//    Surface (
-//        modifier = Modifier.fillMaxSize(),
-//        color = MaterialTheme.colorScheme.background
-//    ) {
-        Scaffold(
-            bottomBar = {
-                NavigationBar() {
-                    items.forEachIndexed { index, item ->
-                        NavigationBarItem(
-                            selected = selectedIndex == index,
-                            onClick = {
-                                selectedIndex = index
-                                val enumVal = GolfBuddyScreenNames.values()[selectedIndex].name
-                                navController.navigate(GolfBuddyScreenNames.values()[selectedIndex].name)
-                            },
-                            label = {
-                                Text(text = item.title)
-                            },
-                            icon = {
-                                Icon(
-                                    imageVector = if (index == selectedIndex) {
-                                        item.selectedIcon
-                                    } else {
-                                        item.unSelectedIcon
-                                    },
-                                    contentDescription = item.title
-                                )
-                            }
-                        )
-                    }
+    Scaffold(
+        bottomBar = {
+            NavigationBar() {
+                items.forEachIndexed { index, item ->
+                    NavigationBarItem(
+                        selected = selectedIndex == index,
+                        onClick = {
+                            selectedIndex = index
+                            navController.navigate(GolfBuddyScreenNames.values()[selectedIndex].name)
+                        },
+                        label = {
+                            Text(text = item.title)
+                        },
+                        icon = {
+                            Icon(
+                                imageVector = if (index == selectedIndex) {
+                                    item.selectedIcon
+                                } else {
+                                    item.unSelectedIcon
+                                },
+                                contentDescription = item.title
+                            )
+                        }
+                    )
                 }
             }
-        ) {
+        }
+    ) { innerPadding ->
+        Box (modifier = Modifier.padding(innerPadding)){
             NavHost(
                 navController = navController,
                 startDestination = GolfBuddyScreenNames.Home.name,
@@ -115,26 +115,30 @@ fun GolfBuddyScreen(
             ) {
                 composable(route = GolfBuddyScreenNames.Home.name) {
                     HomeScreen(
-                        viewModel,
+                        gbViewModel,
                         modifier = Modifier.fillMaxHeight()
                     )
                 }
                 composable(route = GolfBuddyScreenNames.Clubs.name) {
                     ModifyClubsScreen(
-                        viewModel,
+                        gbViewModel,
                         modifier = Modifier.fillMaxHeight()
                     )
                 }
                 composable(route = GolfBuddyScreenNames.Logs.name) {
                     RangeLogsScreen(
+                        rangeLogsViewModel,
+                        navController,
                         modifier = Modifier
                             .fillMaxHeight()
                     )
                 }
+                composable(route =GolfBuddyScreenNames.CreateLogs.name) {
+                    CreateRangeLogScreen(modifier = Modifier.fillMaxHeight())
+                }
             }
         }
-//    }
-
+    }
 }
 
 //@Preview(showBackground = true)

--- a/app/src/main/java/com/example/composegolfbuddy/screens/createrangelog/CreateRangeLogScreen.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/createrangelog/CreateRangeLogScreen.kt
@@ -1,0 +1,10 @@
+package com.example.composegolfbuddy.screens.createrangelog
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun CreateRangeLogScreen(modifier: Modifier) {
+    Text("Create range log screen")
+}

--- a/app/src/main/java/com/example/composegolfbuddy/screens/createrangelog/CreateRangeLogScreen.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/createrangelog/CreateRangeLogScreen.kt
@@ -1,17 +1,30 @@
 package com.example.composegolfbuddy.screens.createrangelog
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Create
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.composegolfbuddy.designsystem.compents.ActionButton
 import com.example.composegolfbuddy.designsystem.compents.MyDatePickerDialog
 import com.example.composegolfbuddy.designsystem.compents.OutlinedLargeTextField
 import com.example.composegolfbuddy.designsystem.compents.OutlinedTextFieldForInputs
@@ -33,14 +46,37 @@ fun CreateRangeLogScreen(
         verticalArrangement = Arrangement.SpaceEvenly
     ) {
 
-        Text("How was your session?\n" +
-                "- Any new feels you want to remember?\n" +
-                "- Mention what went right and what can be worked on")
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = MaterialTheme.colorScheme.primaryContainer,
+                shape = RoundedCornerShape(4.dp)
+            )
+            .padding(4.dp)
+        ) {
+            Text(
+                text = "How was your session?",
+                style = TextStyle(
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 20.sp, // Adjust size as needed
+                ),
+                modifier = Modifier.padding(bottom = 8.dp) // Add spacing below
+            )
+
+            Text(text = "- Any new feels you want to remember?")
+            Text(text = "- Mention what went right and what can be worked on")
+        }
+
 
         Spacer(modifier = modifier.height(16.dp))
 
-        MyDatePickerDialog { viewModel.updateRangeDate(it) }
-        
+//        MyDatePickerDialog { viewModel.updateRangeDate(it) }
+        MyDatePickerDialog(
+            modifier = Modifier,
+            initialDate = viewModel.rangeDate, // Pass the rangeDate value
+            updateDate = { viewModel.updateRangeDate(it) }
+        )
+
         Spacer(modifier = modifier.height(16.dp))
 
 
@@ -79,5 +115,26 @@ fun CreateRangeLogScreen(
             maxLength = 300,
             title = "Summary"
         )
+        Row(
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(8.dp)
+        ) {
+            ActionButton(
+                doAction =  { viewModel.clearAll() },
+                icon = Icons.Filled.Clear,
+                textValue = "Clear"
+            )
+
+            VerticalDivider(modifier.padding(8.dp))
+
+            ActionButton(
+                doAction =  { viewModel.processRangeLog() },
+                icon = Icons.Filled.Create,
+                textValue = "Create"
+            )
+        }
     }
 }
+
+

--- a/app/src/main/java/com/example/composegolfbuddy/screens/createrangelog/CreateRangeLogScreen.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/createrangelog/CreateRangeLogScreen.kt
@@ -70,7 +70,6 @@ fun CreateRangeLogScreen(
 
         Spacer(modifier = modifier.height(16.dp))
 
-//        MyDatePickerDialog { viewModel.updateRangeDate(it) }
         MyDatePickerDialog(
             modifier = Modifier,
             initialDate = viewModel.rangeDate, // Pass the rangeDate value

--- a/app/src/main/java/com/example/composegolfbuddy/screens/createrangelog/CreateRangeLogScreen.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/createrangelog/CreateRangeLogScreen.kt
@@ -1,10 +1,83 @@
 package com.example.composegolfbuddy.screens.createrangelog
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.composegolfbuddy.designsystem.compents.MyDatePickerDialog
+import com.example.composegolfbuddy.designsystem.compents.OutlinedLargeTextField
+import com.example.composegolfbuddy.designsystem.compents.OutlinedTextFieldForInputs
+import com.example.composegolfbuddy.screens.rangelogs.RangeLogsViewModel
 
 @Composable
-fun CreateRangeLogScreen(modifier: Modifier) {
-    Text("Create range log screen")
+fun CreateRangeLogScreen(
+    viewModel: RangeLogsViewModel,
+    modifier: Modifier
+) {
+
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(scrollState),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.SpaceEvenly
+    ) {
+
+        Text("How was your session?\n" +
+                "- Any new feels you want to remember?\n" +
+                "- Mention what went right and what can be worked on")
+
+        Spacer(modifier = modifier.height(16.dp))
+
+        MyDatePickerDialog { viewModel.updateRangeDate(it) }
+        
+        Spacer(modifier = modifier.height(16.dp))
+
+
+        OutlinedTextFieldForInputs(
+            initialValue = viewModel.rangeLocation,
+            valueChanged = { viewModel.updateRangeLocation(it) },
+            isErrorState = false,
+            errorMessage = "",
+            title = "Location",
+            maxLength = 20,
+            modifier = Modifier.weight(1f)
+        )
+        
+        OutlinedTextFieldForInputs(
+            initialValue = viewModel.rangeBallsHit,
+            valueChanged = { viewModel.updateRangeBallsHit(it) },
+            isErrorState = false,
+            errorMessage = "",
+            title = "Balls hit",
+            maxLength = 3
+        )
+
+        OutlinedTextFieldForInputs(
+            initialValue = viewModel.rangeGoal,
+            valueChanged = { viewModel.updateRangeGoal(it) },
+            isErrorState = false,
+            errorMessage = "",
+            title = "Range Goal",
+            maxLength = 40,
+            modifier = Modifier.weight(1f)
+        )
+
+        OutlinedLargeTextField(
+            initialValue = viewModel.rangeSummary,
+            valueChanged = { viewModel.updateRangeSummary(it)},
+            maxLength = 300,
+            title = "Summary"
+        )
+    }
 }

--- a/app/src/main/java/com/example/composegolfbuddy/screens/homeScreen/HomeScreen.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/homeScreen/HomeScreen.kt
@@ -57,7 +57,7 @@ fun ClubInfoRow(club: Club, modifier: Modifier = Modifier) {
             modifier = modifier
                 .fillMaxWidth()
                 .padding(4.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly,
+            horizontalArrangement = Arrangement.Start,
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(

--- a/app/src/main/java/com/example/composegolfbuddy/screens/homeScreen/HomeScreen.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/homeScreen/HomeScreen.kt
@@ -92,14 +92,19 @@ fun ClubInfoRow(club: Club, modifier: Modifier = Modifier) {
                     )
                 )
             }
-
-            Text(
-                text = "Yardage: ${club.distance}",
-                style = TextStyle(
-                    fontSize = 26.sp,
-                ),
+            Column(
+                horizontalAlignment = Alignment.End,
                 modifier = Modifier.padding(2.dp)
-            )
+                    .fillMaxWidth()
+            ) {
+                Text(
+                    text = "${club.distance} Yards",
+                    style = TextStyle(
+                        fontSize = 26.sp,
+                    ),
+                    modifier = Modifier.padding(2.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/composegolfbuddy/screens/modifyclubsscreen/ModifyClubsScreen.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/modifyclubsscreen/ModifyClubsScreen.kt
@@ -26,6 +26,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.example.composegolfbuddy.designsystem.compents.OutlinedTextFieldForInputs
+import com.example.composegolfbuddy.designsystem.compents.OutlinedTextFieldWithDropdown
+import com.example.composegolfbuddy.designsystem.compents.SubmitButton
 import com.example.composegolfbuddy.screens.GbViewModel
 
 @Composable
@@ -78,118 +81,119 @@ fun ModifyClubsScreen(viewModel: GbViewModel, modifier: Modifier = Modifier) {
         SubmitButton(processClubInputs = viewModel::processClubInputs)
     }
 }
+//
+//@OptIn(ExperimentalMaterial3Api::class)
+//@Composable
+//fun OutlinedTextFieldForInputs(
+//    initialValue: String = "",
+//    valueChanged: (String) -> Unit,
+//    isErrorState: Boolean = false,
+//    errorMessage: String,
+//    title: String = "",
+//    maxLength: Int
+//) {
+//    Column(horizontalAlignment = Alignment.Start) {
+//        OutlinedTextField(
+//            value = initialValue,
+//            onValueChange = { newValue ->
+//                if (!newValue.endsWith(' ')) {
+//                    if (newValue.length <= maxLength) {
+//                        valueChanged(newValue)
+//                    }
+//                }
+//            },
+//            label = { Text(title) },
+//            isError = isErrorState,
+//            supportingText = {
+//                if (isErrorState) {
+//                    Text(
+//                        modifier = Modifier.fillMaxWidth(),
+//                        text = errorMessage,
+//                        color = MaterialTheme.colorScheme.error
+//                    )
+//                }
+//            },
+//            singleLine = true
+//        )
+//    }
+//}
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun OutlinedTextFieldForInputs(
-    initialValue: String = "",
-    valueChanged: (String) -> Unit,
-    isErrorState: Boolean = false,
-    errorMessage: String,
-    title: String = "",
-    maxLength: Int
-) {
-    Column(horizontalAlignment = Alignment.Start) {
-        OutlinedTextField(
-            value = initialValue,
-            onValueChange = { newValue ->
-                if (!newValue.endsWith(' ')) {
-                    if (newValue.length <= maxLength) {
-                        valueChanged(newValue)
-                    }
-                }
-            },
-            label = { Text(title) },
-            isError = isErrorState,
-            supportingText = {
-                if (isErrorState) {
-                    Text(
-                        modifier = Modifier.fillMaxWidth(),
-                        text = errorMessage,
-                        color = MaterialTheme.colorScheme.error
-                    )
-                }
-            },
-            singleLine = true
-        )
-    }
-}
+//
+//@OptIn(ExperimentalMaterial3Api::class)
+//@Composable
+//fun OutlinedTextFieldWithDropdown(
+//    initialValue: String = "",
+//    valueChanged: (String) -> Unit,
+//    retrieveClub: () -> Unit,
+//    indexChanged: (Int) -> Unit,
+//    selectedIndex: Int,
+//    isErrorState: Boolean = false,
+//    errorMessage: String,
+//    title: String = "",
+//    options: List<String>
+//) {
+//    var expanded by remember { mutableStateOf(false) }
+//
+//    Column(horizontalAlignment = Alignment.Start) {
+//        Box(modifier = Modifier.clickable { expanded = true }) {
+//            OutlinedTextField(
+//                value = if (selectedIndex != -1) options[selectedIndex] else initialValue,
+//                onValueChange = {
+//                    valueChanged(it)
+//                },
+//                label = { Text(title) },
+//                isError = isErrorState,
+//                readOnly = true,
+//                singleLine = true,
+//                trailingIcon = {
+//                    Icon(
+//                        imageVector = Icons.Default.ArrowDropDown,
+//                        contentDescription = "Dropdown",
+//                        modifier = Modifier.clickable { expanded = true }
+//                    )
+//                }
+//            )
+//        }
+//
+//        DropdownMenu(
+//            expanded = expanded,
+//            onDismissRequest = { expanded = false },
+//            modifier = Modifier
+//                .fillMaxWidth()
+//                .height(400.dp)
+//        ) {
+//            options.forEachIndexed { index, option ->
+//                DropdownMenuItem(
+//                    text = { Text(text = option) },
+//                    onClick = {
+//                        valueChanged(option)
+//                        retrieveClub()
+//                        indexChanged(index)
+//                        expanded = false
+//                    }
+//                )
+//            }
+//        }
+//
+//        if (isErrorState) {
+//            Text(
+//                modifier = Modifier.fillMaxWidth(),
+//                text = errorMessage,
+//                color = MaterialTheme.colorScheme.error
+//            )
+//        }
+//    }
+//}
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun OutlinedTextFieldWithDropdown(
-    initialValue: String = "",
-    valueChanged: (String) -> Unit,
-    retrieveClub: () -> Unit,
-    indexChanged: (Int) -> Unit,
-    selectedIndex: Int,
-    isErrorState: Boolean = false,
-    errorMessage: String,
-    title: String = "",
-    options: List<String>
-) {
-    var expanded by remember { mutableStateOf(false) }
-
-    Column(horizontalAlignment = Alignment.Start) {
-        Box(modifier = Modifier.clickable { expanded = true }) {
-            OutlinedTextField(
-                value = if (selectedIndex != -1) options[selectedIndex] else initialValue,
-                onValueChange = {
-                    valueChanged(it)
-                },
-                label = { Text(title) },
-                isError = isErrorState,
-                readOnly = true,
-                singleLine = true,
-                trailingIcon = {
-                    Icon(
-                        imageVector = Icons.Default.ArrowDropDown,
-                        contentDescription = "Dropdown",
-                        modifier = Modifier.clickable { expanded = true }
-                    )
-                }
-            )
-        }
-
-        DropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(400.dp)
-        ) {
-            options.forEachIndexed { index, option ->
-                DropdownMenuItem(
-                    text = { Text(text = option) },
-                    onClick = {
-                        valueChanged(option)
-                        retrieveClub()
-                        indexChanged(index)
-                        expanded = false
-                    }
-                )
-            }
-        }
-
-        if (isErrorState) {
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                text = errorMessage,
-                color = MaterialTheme.colorScheme.error
-            )
-        }
-    }
-}
-
-@Composable
-fun SubmitButton(modifier: Modifier = Modifier, processClubInputs: () -> Unit) {
-    Button(onClick = {
-        processClubInputs()
-    }) {
-        modifier.padding(8.dp)
-        Text(text = "Add Club")
-    }
-}
+//@Composable
+//fun SubmitButton(modifier: Modifier = Modifier, processClubInputs: () -> Unit) {
+//    Button(onClick = {
+//        processClubInputs()
+//    }) {
+//        modifier.padding(8.dp)
+//        Text(text = "Add Club")
+//    }
+//}
 
 //@Preview(showBackground = true)
 //@Composable

--- a/app/src/main/java/com/example/composegolfbuddy/screens/modifyclubsscreen/ModifyClubsScreen.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/modifyclubsscreen/ModifyClubsScreen.kt
@@ -1,31 +1,12 @@
 package com.example.composegolfbuddy.screens.modifyclubsscreen
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material3.Button
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import com.example.composegolfbuddy.designsystem.compents.OutlinedTextFieldForInputs
 import com.example.composegolfbuddy.designsystem.compents.OutlinedTextFieldWithDropdown
 import com.example.composegolfbuddy.designsystem.compents.SubmitButton
@@ -59,7 +40,8 @@ fun ModifyClubsScreen(viewModel: GbViewModel, modifier: Modifier = Modifier) {
             isErrorState = state.value.clubBrandError,
             errorMessage = state.value.clubBrandErrorMessage,
             title = "Brand",
-            maxLength = 16
+            maxLength = 16,
+            modifier = Modifier.weight(1f)
         )
         OutlinedTextFieldForInputs(
             initialValue = viewModel.clubLoftInput,
@@ -67,7 +49,8 @@ fun ModifyClubsScreen(viewModel: GbViewModel, modifier: Modifier = Modifier) {
             isErrorState = state.value.clubLoftError,
             errorMessage = state.value.clubLoftErrorMessage,
             title = "Club Loft",
-            maxLength = 12
+            maxLength = 12,
+            modifier = Modifier.weight(1f)
         )
         OutlinedTextFieldForInputs(
             initialValue = viewModel.distanceInput,
@@ -75,125 +58,14 @@ fun ModifyClubsScreen(viewModel: GbViewModel, modifier: Modifier = Modifier) {
             isErrorState = state.value.distanceError,
             errorMessage = state.value.distanceErrorMessage,
             title = "Distance",
-            maxLength = 3
+            maxLength = 3,
+            modifier = Modifier.weight(1f)
         )
 
         SubmitButton(processClubInputs = viewModel::processClubInputs)
     }
 }
-//
-//@OptIn(ExperimentalMaterial3Api::class)
-//@Composable
-//fun OutlinedTextFieldForInputs(
-//    initialValue: String = "",
-//    valueChanged: (String) -> Unit,
-//    isErrorState: Boolean = false,
-//    errorMessage: String,
-//    title: String = "",
-//    maxLength: Int
-//) {
-//    Column(horizontalAlignment = Alignment.Start) {
-//        OutlinedTextField(
-//            value = initialValue,
-//            onValueChange = { newValue ->
-//                if (!newValue.endsWith(' ')) {
-//                    if (newValue.length <= maxLength) {
-//                        valueChanged(newValue)
-//                    }
-//                }
-//            },
-//            label = { Text(title) },
-//            isError = isErrorState,
-//            supportingText = {
-//                if (isErrorState) {
-//                    Text(
-//                        modifier = Modifier.fillMaxWidth(),
-//                        text = errorMessage,
-//                        color = MaterialTheme.colorScheme.error
-//                    )
-//                }
-//            },
-//            singleLine = true
-//        )
-//    }
-//}
 
-//
-//@OptIn(ExperimentalMaterial3Api::class)
-//@Composable
-//fun OutlinedTextFieldWithDropdown(
-//    initialValue: String = "",
-//    valueChanged: (String) -> Unit,
-//    retrieveClub: () -> Unit,
-//    indexChanged: (Int) -> Unit,
-//    selectedIndex: Int,
-//    isErrorState: Boolean = false,
-//    errorMessage: String,
-//    title: String = "",
-//    options: List<String>
-//) {
-//    var expanded by remember { mutableStateOf(false) }
-//
-//    Column(horizontalAlignment = Alignment.Start) {
-//        Box(modifier = Modifier.clickable { expanded = true }) {
-//            OutlinedTextField(
-//                value = if (selectedIndex != -1) options[selectedIndex] else initialValue,
-//                onValueChange = {
-//                    valueChanged(it)
-//                },
-//                label = { Text(title) },
-//                isError = isErrorState,
-//                readOnly = true,
-//                singleLine = true,
-//                trailingIcon = {
-//                    Icon(
-//                        imageVector = Icons.Default.ArrowDropDown,
-//                        contentDescription = "Dropdown",
-//                        modifier = Modifier.clickable { expanded = true }
-//                    )
-//                }
-//            )
-//        }
-//
-//        DropdownMenu(
-//            expanded = expanded,
-//            onDismissRequest = { expanded = false },
-//            modifier = Modifier
-//                .fillMaxWidth()
-//                .height(400.dp)
-//        ) {
-//            options.forEachIndexed { index, option ->
-//                DropdownMenuItem(
-//                    text = { Text(text = option) },
-//                    onClick = {
-//                        valueChanged(option)
-//                        retrieveClub()
-//                        indexChanged(index)
-//                        expanded = false
-//                    }
-//                )
-//            }
-//        }
-//
-//        if (isErrorState) {
-//            Text(
-//                modifier = Modifier.fillMaxWidth(),
-//                text = errorMessage,
-//                color = MaterialTheme.colorScheme.error
-//            )
-//        }
-//    }
-//}
-
-//@Composable
-//fun SubmitButton(modifier: Modifier = Modifier, processClubInputs: () -> Unit) {
-//    Button(onClick = {
-//        processClubInputs()
-//    }) {
-//        modifier.padding(8.dp)
-//        Text(text = "Add Club")
-//    }
-//}
 
 //@Preview(showBackground = true)
 //@Composable

--- a/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/CreateRangeLogsUiState.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/CreateRangeLogsUiState.kt
@@ -1,0 +1,7 @@
+package com.example.composegolfbuddy.screens.rangelogs
+
+import com.example.composegolfbuddy.model.RangeLog
+
+data class CreateRangeLogsUiState(
+    var rangeLogsList: List<RangeLog> = emptyList()
+)

--- a/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/RangeLogsScreen.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/RangeLogsScreen.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
 
 package com.example.composegolfbuddy.screens.rangelogs
 
@@ -21,7 +20,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -38,14 +36,12 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
-import com.example.composegolfbuddy.Greeting
 import com.example.composegolfbuddy.designsystem.compents.BoldTextTitleWithContent
 import com.example.composegolfbuddy.designsystem.compents.RangeLogNoteWithScroll
 import com.example.composegolfbuddy.model.RangeLog
 import com.example.composegolfbuddy.screens.GolfBuddyScreenNames
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RangeLogsScreen(
     rangeLogsViewModel: RangeLogsViewModel,
@@ -58,7 +54,6 @@ fun RangeLogsScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceEvenly
     ) {
-        Greeting("Range Logs Coming Soon")
 
         val rangeLog = RangeLog(
             "Location",

--- a/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/RangeLogsScreen.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/RangeLogsScreen.kt
@@ -4,42 +4,17 @@ package com.example.composegolfbuddy.screens.rangelogs
 import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Create
-import androidx.compose.material.icons.filled.DeleteOutline
-import androidx.compose.material.icons.filled.GolfCourse
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ElevatedButton
-import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
-import com.example.composegolfbuddy.designsystem.compents.BoldTextTitleWithContent
-import com.example.composegolfbuddy.designsystem.compents.RangeLogNoteWithScroll
-import com.example.composegolfbuddy.model.RangeLog
-import com.example.composegolfbuddy.screens.GolfBuddyScreenNames
+import com.example.composegolfbuddy.designsystem.compents.RangeLogCard
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
@@ -55,126 +30,16 @@ fun RangeLogsScreen(
         verticalArrangement = Arrangement.SpaceEvenly
     ) {
 
-        val rangeLog = RangeLog(
-            "Location",
-            "DD/MM/YY",
-            "Hit it straight",
-            "100",
-            "Lorem Lipsum Lorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem Lipsum"
-        )
-        val rangeLogList = listOf(rangeLog, rangeLog, rangeLog)
+        val createRangeLogsUiState by rangeLogsViewModel.createRangeLogsUiState.collectAsState()
 
         Scaffold {
-
             Column(horizontalAlignment = Alignment.End) {
-                Row() {
-                    ElevatedButton(onClick = { navController.navigate(GolfBuddyScreenNames.CreateLogs.name) }) {
-                        Text(
-                            text = "Create",
-                            style = MaterialTheme.typography.headlineSmall,
-                        )
-                        Icon(
-                            Icons.Filled.Create,
-                            "description",
-                            modifier = Modifier
-                                .padding(4.dp)
-                                .size(26.dp)
-                        )
-
-                    }
-                }
                 LazyColumn {
-                    items(rangeLogList) { log ->
+                    items(createRangeLogsUiState.rangeLogsList) { log ->
                         RangeLogCard(log)
                     }
                 }
             }
-        }
-    }
-}
-
-@Composable
-fun RangeLogCard(rangeLog: RangeLog) {
-    ElevatedCard(modifier = Modifier
-        .fillMaxWidth()
-        .padding(8.dp)
-        .height(250.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant,
-        )
-
-    ){
-        var expanded by rememberSaveable { mutableStateOf(false) }
-
-        Column(){
-            Row(modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            )
-            {
-                Row(horizontalArrangement = Arrangement.Start)
-                {
-                    Icon(Icons.Filled.GolfCourse,
-                        "description",
-                        modifier = Modifier
-                            .padding(4.dp)
-                            .size(32.dp)
-                        )
-                    Column() {
-                        Text(
-                            text = rangeLog.location,
-                            style = TextStyle(
-                                fontSize = 16.sp
-                            )
-                        )
-                        Text(
-                            text = rangeLog.date,
-                            style = TextStyle(
-                                fontSize = 16.sp
-                            )
-                        )
-                    }
-                }
-                Row (modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End)
-                {
-                    IconButton(onClick = { expanded = true }) {
-                        Icon(Icons.Filled.DeleteOutline, "Floating action button.")
-                    }
-                    DropdownMenu(
-                        expanded = expanded,
-                        onDismissRequest = { expanded = false },
-                        modifier = Modifier
-//                            .width()
-//                            .height(100.dp)
-                    ) {
-                        DropdownMenuItem(
-                            text = { Text(text = "Delete") },
-                            onClick = {
-                                // Delete Post
-                                expanded = false
-                            }
-                        )
-                    }
-                }
-            }
-
-            Column(modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp)
-            ){
-                BoldTextTitleWithContent(
-                    "Goal: ",
-                    rangeLog.goal,
-                    16
-                )
-                BoldTextTitleWithContent(
-                    "Balls hit: ",
-                    rangeLog.ballShit,
-                    16
-                )
-                RangeLogNoteWithScroll(rangeLog.note, size = 16)
-            }
-
         }
     }
 }

--- a/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/RangeLogsScreen.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/RangeLogsScreen.kt
@@ -1,10 +1,186 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.example.composegolfbuddy.screens.rangelogs
 
+import android.annotation.SuppressLint
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Create
+import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material.icons.filled.GolfCourse
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
 import com.example.composegolfbuddy.Greeting
+import com.example.composegolfbuddy.designsystem.compents.BoldTextTitleWithContent
+import com.example.composegolfbuddy.designsystem.compents.RangeLogNoteWithScroll
+import com.example.composegolfbuddy.model.RangeLog
+import com.example.composegolfbuddy.screens.GolfBuddyScreenNames
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RangeLogsScreen(
+    rangeLogsViewModel: RangeLogsViewModel,
+    navController: NavHostController,
+    modifier: Modifier = Modifier
+) {
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.SpaceEvenly
+    ) {
+        Greeting("Range Logs Coming Soon")
+
+        val rangeLog = RangeLog(
+            "Location",
+            "DD/MM/YY",
+            "Hit it straight",
+            "100",
+            "Lorem Lipsum Lorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem LipsumLorem Lipsum"
+        )
+        val rangeLogList = listOf(rangeLog, rangeLog, rangeLog)
+
+        Scaffold {
+
+            Column(horizontalAlignment = Alignment.End) {
+                Row() {
+                    ElevatedButton(onClick = { navController.navigate(GolfBuddyScreenNames.CreateLogs.name) }) {
+                        Text(
+                            text = "Create",
+                            style = MaterialTheme.typography.headlineSmall,
+                        )
+                        Icon(
+                            Icons.Filled.Create,
+                            "description",
+                            modifier = Modifier
+                                .padding(4.dp)
+                                .size(26.dp)
+                        )
+
+                    }
+                }
+                LazyColumn {
+                    items(rangeLogList) { log ->
+                        RangeLogCard(log)
+                    }
+                }
+            }
+        }
+    }
+}
 
 @Composable
-fun RangeLogsScreen(modifier: Modifier = Modifier) {
-    Greeting("Range Logs Coming Soon")
+fun RangeLogCard(rangeLog: RangeLog) {
+    ElevatedCard(modifier = Modifier
+        .fillMaxWidth()
+        .padding(8.dp)
+        .height(250.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        )
+
+    ){
+        var expanded by rememberSaveable { mutableStateOf(false) }
+
+        Column(){
+            Row(modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            )
+            {
+                Row(horizontalArrangement = Arrangement.Start)
+                {
+                    Icon(Icons.Filled.GolfCourse,
+                        "description",
+                        modifier = Modifier
+                            .padding(4.dp)
+                            .size(32.dp)
+                        )
+                    Column() {
+                        Text(
+                            text = rangeLog.location,
+                            style = TextStyle(
+                                fontSize = 16.sp
+                            )
+                        )
+                        Text(
+                            text = rangeLog.date,
+                            style = TextStyle(
+                                fontSize = 16.sp
+                            )
+                        )
+                    }
+                }
+                Row (modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End)
+                {
+                    IconButton(onClick = { expanded = true }) {
+                        Icon(Icons.Filled.DeleteOutline, "Floating action button.")
+                    }
+                    DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false },
+                        modifier = Modifier
+//                            .width()
+//                            .height(100.dp)
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text(text = "Delete") },
+                            onClick = {
+                                // Delete Post
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+
+            Column(modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+            ){
+                BoldTextTitleWithContent(
+                    "Goal: ",
+                    rangeLog.goal,
+                    16
+                )
+                BoldTextTitleWithContent(
+                    "Balls hit: ",
+                    rangeLog.ballShit,
+                    16
+                )
+                RangeLogNoteWithScroll(rangeLog.note, size = 16)
+            }
+
+        }
+    }
 }
+

--- a/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/RangeLogsViewModel.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/RangeLogsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.composegolfbuddy.model.RangeLog
 import com.example.composegolfbuddy.usecases.AddRangeLogUseCase
+import com.example.composegolfbuddy.usecases.DeleteRangeLogUseCase
 import com.example.composegolfbuddy.usecases.GetAllRangeLogsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,7 +22,8 @@ import javax.inject.Inject
 @HiltViewModel
 class RangeLogsViewModel @Inject constructor(
     private val addRangeLogUseCase: AddRangeLogUseCase,
-    private val getAllRangeLogsUseCase: GetAllRangeLogsUseCase
+    private val getAllRangeLogsUseCase: GetAllRangeLogsUseCase,
+    private val deleteRangeLogUseCase: DeleteRangeLogUseCase
 ) : ViewModel() {
 
     private var _createRangeLogsUiState = MutableStateFlow(CreateRangeLogsUiState())
@@ -95,6 +97,12 @@ class RangeLogsViewModel @Inject constructor(
         }
     }
 
+    fun deleteById(id: String) {
+        viewModelScope.launch {
+            deleteRangeLogUseCase.invoke(id)
+            populateRangeLogsList()
+        }
+    }
 
     private fun createRangeLog() = viewModelScope.launch {
         addRangeLogUseCase.insertRangeLog(

--- a/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/RangeLogsViewModel.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/RangeLogsViewModel.kt
@@ -1,5 +1,8 @@
 package com.example.composegolfbuddy.screens.rangelogs
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -7,5 +10,43 @@ import javax.inject.Inject
 @HiltViewModel
 class RangeLogsViewModel @Inject constructor() : ViewModel() {
 
+    var rangeLocation by mutableStateOf("")
+        private set
+    var rangeDate by mutableStateOf("")
+        private set
+    var rangeGoal by mutableStateOf("")
+        private set
+    var rangeBallsHit by mutableStateOf("")
+        private set
+    var rangeSummary by mutableStateOf("")
+        private set
+
+    fun updateRangeLocation(value: String) {
+        rangeLocation = value
+    }
+
+    fun updateRangeDate(value: String) {
+        rangeDate = value
+    }
+
+    fun updateRangeGoal(value: String) {
+        rangeGoal = value
+    }
+
+    fun updateRangeBallsHit(value: String) {
+        rangeBallsHit = value
+    }
+
+    fun updateRangeSummary(value: String) {
+        rangeSummary = value
+    }
+
+    init {
+        rangeLocation = ""
+        rangeDate = ""
+        rangeGoal = ""
+        rangeBallsHit = ""
+        rangeSummary = ""
+    }
 
 }

--- a/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/RangeLogsViewModel.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/screens/rangelogs/RangeLogsViewModel.kt
@@ -1,0 +1,11 @@
+package com.example.composegolfbuddy.screens.rangelogs
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class RangeLogsViewModel @Inject constructor() : ViewModel() {
+
+
+}

--- a/app/src/main/java/com/example/composegolfbuddy/usecases/AddClubUseCase.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/usecases/AddClubUseCase.kt
@@ -1,4 +1,4 @@
-package com.multiplatform.clubdistances.homeScreen.useCases
+package com.example.composegolfbuddy.usecases
 
 import com.example.composegolfbuddy.repositories.ClubsRepository
 import com.multiplatform.clubdistances.homeScreen.model.Club

--- a/app/src/main/java/com/example/composegolfbuddy/usecases/AddRangeLogUseCase.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/usecases/AddRangeLogUseCase.kt
@@ -1,0 +1,14 @@
+package com.example.composegolfbuddy.usecases
+
+import com.example.composegolfbuddy.model.RangeLog
+import com.example.composegolfbuddy.repositories.RangeLogsRepository
+import javax.inject.Inject
+
+class AddRangeLogUseCase @Inject constructor(
+    private val rangeLogsRepository: RangeLogsRepository
+) {
+
+    suspend fun insertRangeLog(rangeLog: RangeLog) {
+        rangeLogsRepository.insertRangeLog(rangeLog)
+    }
+}

--- a/app/src/main/java/com/example/composegolfbuddy/usecases/DeleteRangeLogUseCase.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/usecases/DeleteRangeLogUseCase.kt
@@ -1,0 +1,13 @@
+package com.example.composegolfbuddy.usecases
+
+import com.example.composegolfbuddy.repositories.RangeLogsRepository
+import javax.inject.Inject
+
+class DeleteRangeLogUseCase @Inject constructor(
+    private val rangeLogsRepository: RangeLogsRepository
+) {
+
+    suspend fun invoke(id: String) {
+        rangeLogsRepository.deleteById(id)
+    }
+}

--- a/app/src/main/java/com/example/composegolfbuddy/usecases/GetAllRangeLogsUseCase.kt
+++ b/app/src/main/java/com/example/composegolfbuddy/usecases/GetAllRangeLogsUseCase.kt
@@ -1,0 +1,26 @@
+package com.example.composegolfbuddy.usecases
+
+import com.example.composegolfbuddy.model.RangeLog
+import com.example.composegolfbuddy.repositories.RangeLogsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.text.SimpleDateFormat
+import java.util.Locale
+import javax.inject.Inject
+
+class GetAllRangeLogsUseCase @Inject constructor(
+    private val rangeLogsRepository: RangeLogsRepository
+) {
+    fun invoke() : Flow<List<RangeLog>> {
+        return sortRangeLogsByDate(rangeLogsRepository.getAllRangeLogs())
+    }
+
+    private fun sortRangeLogsByDate(rangeLogsFlow: Flow<List<RangeLog>>): Flow<List<RangeLog>> {
+        val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+        return rangeLogsFlow.map { rangeLogs ->
+            rangeLogs.sortedByDescending {
+                dateFormat.parse(it.date)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added range log screens. The create range log screen allows users to give details about their range session and summary. The goal is to let user make note of what was important so as not to forget what they learned at the next range session.

the view range logs screen allows users to view their previous range log notes.